### PR TITLE
world peace

### DIFF
--- a/app/channels/lists_channel.rb
+++ b/app/channels/lists_channel.rb
@@ -1,0 +1,5 @@
+class ListsChannel < ApplicationCable::Channel
+  def subscribed
+    stream_from "lists"
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,16 @@ class ApplicationController < ActionController::Base
 
   protected
 
-    def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-      devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+  end
+
+  def authenticate_user!
+    if user_signed_in?
+      super
+    else
+      redirect_to new_user_session_path
     end
+  end
 end

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,4 +1,5 @@
 class ListsController < ApplicationController
+  before_action :authenticate_user!
   before_action :set_list, only: [:show, :edit, :update, :destroy, :move]
 
   # GET /lists

--- a/app/javascript/channels/lists_channel.js
+++ b/app/javascript/channels/lists_channel.js
@@ -1,0 +1,8 @@
+import consumer from './consumer'
+import CableReady from 'cable_ready'
+
+consumer.subscriptions.create('ListsChannel', {
+  received (data) {
+    if (data.cableReady) CableReady.perform(data.operations)
+  }
+})

--- a/app/javascript/controllers/board_controller.js
+++ b/app/javascript/controllers/board_controller.js
@@ -1,18 +1,23 @@
-import SortableController from "controllers/sortable_controller"
+import SortableController from 'controllers/sortable_controller'
 
 export default class extends SortableController {
-  sorted(event) {
+  sorted (event) {
     this.lastId = Math.random()
-    this.stimulate("ListReflex#move", event.item, {
+    this.stimulate('ListReflex#move', event.item, {
       position: event.newIndex + 1,
       forceUpdateId: this.lastId
     })
   }
 
-  create_list(event) {
+  create_list (event) {
     event.preventDefault()
     let formData = new FormData(event.target)
     let data = Object.fromEntries(formData.entries())
-    this.stimulate("ListReflex#create", data)
+    this.stimulate('ListReflex#create', data)
+  }
+
+  reload (event) {
+    event.preventDefault()
+    this.stimulate('ListReflex#reload')
   }
 }

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,4 +1,13 @@
 class List < ApplicationRecord
+  include CableReady::Broadcaster
+  after_save do
+    cable_ready["lists"].inner_html(
+      selector: "#lists",
+      html: ApplicationController.renderer.render(partial: "lists/list", collection: List.order(position: :asc))
+    )
+    cable_ready.broadcast
+  end
+
   has_many :todos, -> { order(position: :asc) }, dependent: :destroy
 
   acts_as_list

--- a/app/reflexes/list_reflex.rb
+++ b/app/reflexes/list_reflex.rb
@@ -31,4 +31,7 @@ class ListReflex < ApplicationReflex
 
     force_update(options["forceUpdateId"])
   end
+
+  def reload
+  end
 end

--- a/app/views/lists/_list.html.erb
+++ b/app/views/lists/_list.html.erb
@@ -1,0 +1,18 @@
+<%= content_tag :div, id: dom_id(list), class: ["col-sm-3", dom_class(list)], data: { id: list.id } do %>
+  <div class="card card-body bg-light">
+    <h6><%= link_to list.name, list %></h6>
+
+    <div data-controller="list" data-list-group="todos" data-id="<%= list.id %>">
+      <% list.todos.each do |todo| %>
+        <div class="card card-body mb-2" data-id="<%= todo.id %>">
+          <%= todo.description %>
+        </div>
+      <% end %>
+    </div>
+
+    <div data-reflex-permanent data-controller="toggle" data-toggle-class="d-none">
+      <%= link_to "Add todo", new_list_todo_path(list), data: { action: "click->toggle#toggle" }, class: "btn btn-light btn-block" %>
+      <%= render "todos/form", todo: Todo.new, list: list, class: "d-none", data: { target: "toggle.toggleable" } %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/lists/index.html.erb
+++ b/app/views/lists/index.html.erb
@@ -3,35 +3,17 @@
     <h1>Lists</h1>
   </div>
 
-  <div class="col-sm-6 text-right">
+  <div class="col-sm-6 text-right" data-controller="board" data-action="force:update@document->board#reload">
+    <button class="btn btn-primary" data-action="click->board#reload">Reload Controller</button>
+    <button class="btn btn-primary" data-reflex="click->ListReflex#reload">Reload No Controller</button>
     <%= link_to new_list_path, class: 'btn btn-primary' do %>
       Add New List
     <% end %>
   </div>
 </div>
 
-<div class="row" data-controller="board" data-action="force:update@document->board#reload">
-  <% @lists.each do |list| %>
-    <%= content_tag :div, id: dom_id(list), class: ["col-sm-3", dom_class(list)], data: { id: list.id } do %>
-      <div class="card card-body bg-light">
-        <h6><%= link_to list.name, list %></h6>
-
-        <div data-controller="list" data-list-group="todos" data-id="<%= list.id %>">
-          <% list.todos.each do |todo| %>
-            <div class="card card-body mb-2" data-id="<%= todo.id %>">
-              <%= todo.description %>
-            </div>
-          <% end %>
-        </div>
-
-        <div data-reflex-permanent data-controller="toggle" data-toggle-class="d-none">
-          <%= link_to "Add todo", new_list_todo_path(list), data: { action: "click->toggle#toggle" }, class: "btn btn-light btn-block" %>
-          <%= render "todos/form", todo: Todo.new, list: list, class: "d-none", data: { target: "toggle.toggleable" } %>
-        </div>
-      </div>
-    <% end %>
-  <% end %>
-
+<div id="lists" class="row">
+  <%= render partial: "list", collection: @lists %>
   <%= content_tag :div, class: ["col-sm-3"] do %>
     <div data-reflex-permanent data-controller="toggle" data-toggle-class="d-none">
       <%= link_to "Add List", new_list_path, data: { action: "click->toggle#toggle" }, class: "btn btn-light btn-block" %>

--- a/test/channels/lists_channel_test.rb
+++ b/test/channels/lists_channel_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ListsChannelTest < ActionCable::Channel::TestCase
+  # test "subscribes" do
+  #   subscribe
+  #   assert subscription.confirmed?
+  # end
+end


### PR DESCRIPTION
Hey Chris, sorry for the delay. I published two npm packages and fully refreshed the StimulusReflex documentation this week. :)

I wasn't able (or supposed to) get everything working, I don't think, but it's in better shape than before:

- Lists index view now renders a collection of list partials (important)
- Added two extra buttons to show a "reload" operation - literally just calling a reflex action that does nothing - both with and without a Stimulus controller
- created a lists channel for CableReady
- set up an after_save callback on the lists model to send an inner_html broadcast that updates the lists displayed (might be firing during drag/drop too, which could mean the DOM is updating twice! I'll leave this as an exercise for you to explore)

Three thoughts:
- doing a reload/refresh is great; updating exactly what changed is greater
- in the new version of SR coming out **today** you'll be able to call `this.stimulate()` (no params) or use `<button data-reflex="click">Refresh</button>` and it will call an empty reflex action that you don't even have to define yourself
- in an application like this, i'd be tempted to have a lists channel for `stream_to "lists"` and a list channel that `stream_for List.find(params[:list_id])` so you can update individual elements and not just the whole collection

Once you reach production speed with this development model, it's insane how quickly the SR+CR pattern pays off. SR gets all of the attention but if I could only have one, I'd keep CableReady. It is the workhorse.